### PR TITLE
LIBSEARCH-170. Updated to use "title" parameter for search result title

### DIFF
--- a/app/searchers/quick_search/maryland_map_searcher.rb
+++ b/app/searchers/quick_search/maryland_map_searcher.rb
@@ -12,7 +12,7 @@ module QuickSearch
       return @results_list if @results_list
 
       @results_list = @response['resultList'].map do |value|
-        result = OpenStruct.new(title: value['displayName'],
+        result = OpenStruct.new(title: value['title'],
                                 link: value['detailLink'],
                                 description: description(value))
         result.date << build_restricted_link if value['restricted']


### PR DESCRIPTION
Replaced the "displayName" parameter with the "title" parameter, which
better matches the actual page title.

https://issues.umd.edu/browse/LIBSEARCH-170